### PR TITLE
Add route /credentials/derive POST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - `@digitalbazaar/credentials-v2-context` is now in the documentLoader.
 - `@digitalbazaar/multikey-context` is now in the documentLoader.
+- POST /`credentials/derive` added.
 
 ### Fixed
 - Revert to `node:20-alpine` in Dockerfile.

--- a/lib/routes/handler.js
+++ b/lib/routes/handler.js
@@ -1,0 +1,26 @@
+/*!
+ * Copyright (c) 2024 Digital Bazaar, Inc.
+ */
+import * as vc from '@digitalbazaar/vc';
+import assert from 'assert-plus';
+import {
+  createDiscloseCryptosuite as createEcdsaSd2023DiscloseCryptosuite
+} from '@digitalbazaar/ecdsa-sd-2023-cryptosuite';
+import {DataIntegrityProof} from '@digitalbazaar/data-integrity';
+import {loader} from '../documentLoader.js';
+
+const documentLoader = loader.build();
+
+export async function deriveHandler(req, res) {
+  const {options: {selectivePointers}, verifiableCredential} = req.body;
+  assert.optionalArrayOfString(selectivePointers, 'selectivePointers');
+  assert.object(verifiableCredential, 'verifiableCredential');
+  const cryptosuite = createEcdsaSd2023DiscloseCryptosuite({selectivePointers});
+  const suite = new DataIntegrityProof({cryptosuite});
+  const derivedVC = await vc.derive({
+    verifiableCredential,
+    suite,
+    documentLoader
+  });
+  res.send({verifiableCredential: derivedVC});
+}

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -1,32 +1,13 @@
 /*!
- * Copyright (c) 2023 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2023 - 2024 Digital Bazaar, Inc.
  */
-import * as vc from '@digitalbazaar/vc';
-import assert from 'assert-plus';
-import {
-  createDiscloseCryptosuite as createEcdsaSd2023DiscloseCryptosuite
-} from '@digitalbazaar/ecdsa-sd-2023-cryptosuite';
-import {DataIntegrityProof} from '@digitalbazaar/data-integrity';
+import {deriveHandler} from './handler.js';
 import express from 'express';
-import {loader} from '../documentLoader.js';
-
-const documentLoader = loader.build();
 
 export const router = express.Router();
 
-router.post('/derive', asyncHandler(async (req, res) => {
-  const {options: {selectivePointers}, verifiableCredential} = req.body;
-  assert.optionalArrayOfString(selectivePointers, 'selectivePointers');
-  assert.object(verifiableCredential, 'verifiableCredential');
-  const cryptosuite = createEcdsaSd2023DiscloseCryptosuite({selectivePointers});
-  const suite = new DataIntegrityProof({cryptosuite});
-  const derivedVC = await vc.derive({
-    verifiableCredential,
-    suite,
-    documentLoader
-  });
-  res.send({verifiableCredential: derivedVC});
-}));
+router.post('/derive', asyncHandler(deriveHandler));
+router.post('/credentials/derive', asyncHandler(deriveHandler));
 
 function asyncHandler(middleware) {
   return function asyncMiddleware(...args) {


### PR DESCRIPTION
1. Adds a new route `/credentials/derive`
2. Abstracts the derive logic into a separate handler
- [x] Test both derive routes with existing `ecdsa-sd-2023` test suite to ensure routes function as expected.

Addresses: https://github.com/digitalbazaar/vc-holder-http/issues/6